### PR TITLE
Fix GitHub link in header

### DIFF
--- a/src/components/Shell/Shell.tsx
+++ b/src/components/Shell/Shell.tsx
@@ -33,7 +33,7 @@ export function Shell({ children }: ShellProps) {
 
           <HeaderControls
             visibleFrom="sm"
-            githubLink="https://github.com/mantine.dev/mantine"
+            githubLink="https://github.com/mantinedev/help.mantine.dev"
             withDirectionToggle={false}
             withSearch={false}
             discordLink={meta.discordLink}


### PR DESCRIPTION
Should it have been a link to the main repo instead? If so, it should link to https://github.com/mantinedev/mantine instead of https://github.com/mantine.dev/mantine.